### PR TITLE
Dependabot automerge fix and dependabot grouped updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,28 +4,28 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    groups:
+      all-in-one:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: nuget
-    directory: /AzDoExtensionNews/AzDoExtensionNews.UnitTests
+    directory: 
+     - /AzDoExtensionNews/AzDoExtensionNews.UnitTests
+     - /AzDoExtensionNews/AzDoExtensionNews
+     - /AzDoExtensionNews/GitHubActionsNews.Tests
+     - /AzDoExtensionNews/GitHubActionsNews
+     - /AzDoExtensionNews/News.Library
     schedule:
       interval: monthly
+    groups:
+      all-in-one:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
-  - package-ecosystem: nuget
-    directory: /AzDoExtensionNews/AzDoExtensionNews
-    schedule:
-      interval: monthly
-
-  - package-ecosystem: nuget
-    directory: /AzDoExtensionNews/GitHubActionsNews.Tests
-    schedule:
-      interval: monthly
-
-  - package-ecosystem: nuget
-    directory: /AzDoExtensionNews/GitHubActionsNews
-    schedule:
-      interval: monthly
-
-  - package-ecosystem: nuget
-    directory: /AzDoExtensionNews/News.Library
-    schedule:
-      interval: monthly

--- a/.github/workflows/auto-approve-dependabot-prs.yml
+++ b/.github/workflows/auto-approve-dependabot-prs.yml
@@ -3,14 +3,14 @@ on:
   pull_request:
 
 permissions:
-  contents: write
-  pull-requests: write
-  
+  contents: read
+
 jobs:
   dependabot:
     permissions:
+      contents: write
+      pull-requests: write
       actions: write
-      contents: read
     uses: devops-actions/.github/.github/workflows/approve-dependabot-pr.yml@main
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -6,7 +6,8 @@ on:
     - Directory.Packages.props
     - AzDoExtensionNews/**
     - .github/workflows/ci-build.yml
-    
+  # required workflow for the PR builds as well
+  pull_request:
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This pull request includes changes to the `.github/dependabot.yml`, `.github/workflows/auto-approve-dependabot-prs.yml`, and `.github/workflows/ci-build.yml` files. The changes primarily involve modifying the configuration for Dependabot and the permissions for GitHub workflows. 

Dependabot configuration changes:
* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R7-L31): The `directory` field for the `nuget` package ecosystem has been updated to include multiple directories instead of just one. Additionally, a `groups` field has been added to group all updates into one and specify that only minor and patch updates should be considered.

GitHub workflow permission changes:
* [`.github/workflows/auto-approve-dependabot-prs.yml`](diffhunk://#diff-f52fd49480fede22aa7e742eea7f95fac90527111276e3a6a0fbb8629fe62387L6-L13): The base permissions for the workflow have been changed from `write` to `read` for `contents`, and `write` permissions for `contents` and `pull-requests` have been moved to the `dependabot` job.
* [`.github/workflows/ci-build.yml`](diffhunk://#diff-68ba9d12f6f2601fe3c9f7f9d0d02aaea52384559d6d08fae7afc941663fdfcdL9-R10): The `pull_request` event has been added to the `on` field to trigger the workflow for pull requests.