### PR TITLE
Replace GitHub Models API with local Ollama inference

### DIFF
--- a/.github/actions/setup-ollama/action.yml
+++ b/.github/actions/setup-ollama/action.yml
@@ -1,0 +1,59 @@
+name: "Setup Ollama (cache + pull)"
+description: >-
+  Restore the cached Ollama model volume, wait for the Ollama service to be
+  ready, and pull the requested model if it is not already cached. The job must
+  declare an `ollama` service container with the volume mount
+  `/home/runner/.ollama:/root/.ollama` so pulled models land in `~/.ollama/models`
+  on the host and can be cached between runs. Models run locally on the runner —
+  no external AI tokens are used.
+
+inputs:
+  model:
+    description: "Ollama model tag to ensure is available (e.g. qwen2.5-coder:3b)."
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Cache Ollama models
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/.ollama/models
+        key: ollama-${{ runner.os }}-${{ inputs.model }}
+        restore-keys: |
+          ollama-${{ runner.os }}-
+
+    - name: Wait for the Ollama service
+      shell: bash
+      run: |
+        echo "Waiting for the Ollama service to be ready..."
+        for i in $(seq 1 30); do
+          if curl -fsS http://localhost:11434/api/tags >/dev/null 2>&1; then
+            echo "Ollama is ready (attempt $i)"
+            break
+          fi
+          sleep 2
+        done
+        curl -fsS http://localhost:11434/api/tags >/dev/null
+
+    - name: Ensure the model is available
+      shell: bash
+      env:
+        MODEL: ${{ inputs.model }}
+      run: |
+        if curl -fsS http://localhost:11434/api/tags | python3 -c "
+        import json, os, sys
+        d = json.load(sys.stdin)
+        m = os.environ['MODEL']
+        names = [x.get('name', '') for x in d.get('models', [])]
+        ok = m in names or (':' not in m and any(n.split(':')[0] == m for n in names))
+        sys.exit(0 if ok else 1)
+        "; then
+          echo "Model ${MODEL} already present (cache hit)."
+        else
+          echo "Pulling ${MODEL} (this populates the cache for next time)..."
+          curl -fsS -X POST http://localhost:11434/api/pull \
+            -H "Content-Type: application/json" \
+            -d "{\"name\":\"${MODEL}\",\"stream\":false}" \
+            --max-time 1800
+        fi

--- a/.github/workflows/action-summary-prompt.txt
+++ b/.github/workflows/action-summary-prompt.txt
@@ -12,6 +12,7 @@ Do NOT include:
 - Version history or changelog information
 
 Keep the summary clear, professional, and user-focused.
+Summary must be in English
 
 README Content:
 {README_CONTENT}

--- a/.github/workflows/createBlogPostsFromUpdates.ps1
+++ b/.github/workflows/createBlogPostsFromUpdates.ps1
@@ -2,15 +2,12 @@ Param(
     [Parameter(Mandatory = $true)]
     [string]$token,
     [Parameter(Mandatory = $true)]
-    [string]$tokenModels,
-    [Parameter(Mandatory = $true)]
     [string]$filePath
 )
 
 # load the dependents functions
 . $PSScriptRoot/dependents.ps1
 Write-Host "Got a token with length $($token.Length)"
-Write-Host "Got a tokenModels with length $($tokenModels.Length)"
 Write-Host "Got this file path $($filePath)"
 Write-Host "We are running from this location: $PSScriptRoot"
 Get-Location
@@ -171,7 +168,7 @@ function LoadPromptTemplate {
     }
 }
 
-function CallGitHubModels {
+function CallOllama {
     Param (
         [Parameter(Mandatory = $true)]
         [string] $prompt,
@@ -182,57 +179,45 @@ function CallGitHubModels {
 
     $maxAttempts = 2
     $backoffSeconds = 30
+    $ollamaUrl = $env:OLLAMA_URL ?? "http://localhost:11434"
+    $model = $env:OLLAMA_MODEL ?? "qwen2.5-coder:3b"
 
     try {
-        # Replace the README content placeholder in the prompt
         $fullPrompt = $prompt -replace '\{README_CONTENT\}', $readmeContent
 
-        # Prepare the request body for GitHub Models API
         $body = @{
+            model = $model
+            stream = $false
             messages = @(
                 @{
                     role = "user"
                     content = $fullPrompt
                 }
             )
-            model = "gpt-4o"
-            temperature = 0.7
-            max_tokens = 500
+            options = @{
+                temperature = 0.7
+                num_predict = 500
+            }
         } | ConvertTo-Json -Depth 10
 
-        $headers = @{
-            Authorization = "Bearer $tokenModels"
-            'Content-Type' = 'application/json'
-            'User-Agent' = 'github-actions-marketplace-news'
-        }
+        $url = "$($ollamaUrl.TrimEnd('/'))/api/chat"
+        $response = Invoke-RestMethod -Uri $url -Method Post -Body $body -ContentType "application/json" -ErrorAction Stop
 
-        # Call GitHub Models API
-        $url = "https://models.inference.ai.azure.com/chat/completions"
-        $response = Invoke-RestMethod -Uri $url -Method Post -Headers $headers -Body $body -ErrorAction Stop
-
-        if ($response.choices -and $response.choices.Count -gt 0) {
-            return $response.choices[0].message.content.Trim()
+        if ($response.message -and $response.message.content) {
+            return $response.message.content.Trim()
         }
         else {
-            throw "No response from GitHub Models API"
+            throw "No response from Ollama"
         }
     }
     catch {
         $errorMessage = $_.Exception.Message
-        Write-Warning "Attempt $attempt failed to call GitHub Models API: $errorMessage"
-        
-        # Check if this is a rate limiting error
-        if ($errorMessage -match "rate limit" -or $errorMessage -match "429" -or $errorMessage -match "Too Many Requests") {
-            Write-Warning "Rate limiting detected, implementing backoff..."
-        }
+        Write-Warning "Attempt $attempt failed to call Ollama: $errorMessage"
 
-        # Retry logic
         if ($attempt -lt $maxAttempts) {
             Write-Host "Waiting $backoffSeconds seconds before retry $($attempt + 1)/$maxAttempts..."
             Start-Sleep -Seconds $backoffSeconds
-            # Exponential backoff for second attempt
-            $nextBackoff = $backoffSeconds * 2
-            return CallGitHubModels -prompt $prompt -readmeContent $readmeContent -attempt ($attempt + 1)
+            return CallOllama -prompt $prompt -readmeContent $readmeContent -attempt ($attempt + 1)
         }
         else {
             Write-Warning "Failed to generate action summary after $maxAttempts attempts"
@@ -270,8 +255,7 @@ function GetActionSummary {
             $readmeContent = $readmeContent.Substring(0, 4000) + "`n`n[README truncated for summary generation]"
         }
 
-        # Call GitHub Models API
-        $summary = CallGitHubModels -prompt $promptTemplate -readmeContent $readmeContent -attempt 1
+        $summary = CallOllama -prompt $promptTemplate -readmeContent $readmeContent -attempt 1
         
         return $summary
     }
@@ -402,6 +386,10 @@ function GetContent {
     }
     if ($update.NodeVersion) {
         $content += "nodeVersion: $(SanitizeContent $update.NodeVersion)"
+    }
+    if ($actionSummary -and $actionSummary -ne "") {
+        $content += "actionSummary: |"
+        $content += "  $($actionSummary.Replace("`n", "`n  "))"
     }
     $content += "---"
     $content += ""

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -177,6 +177,13 @@ jobs:
     environment:
       name: BlogSite
       url: https://github.com/devops-actions/github-actions-marketplace-news
+    services:
+      ollama:
+        image: ollama/ollama:0.23.4
+        ports:
+          - 11434:11434
+        volumes:
+          - /home/runner/.ollama:/root/.ollama
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -190,12 +197,19 @@ jobs:
           ls -la
           cat ArtifactFolder/Actions-Updated-Overview.json
 
+      - name: Set up Ollama
+        uses: ./.github/actions/setup-ollama
+        with:
+          model: qwen2.5-coder:3b
+
       - name: Create blogposts updates for updates
         shell: pwsh
+        env:
+          OLLAMA_MODEL: qwen2.5-coder:3b
         run: |
           ls
           cd .github/workflows/
           ls
 
           $filePath = Resolve-Path "..\..\ArtifactFolder\Actions-Updated-Overview.json"
-          .\createBlogPostsFromUpdates.ps1 -token ${{ secrets.PAT }} -tokenModels ${{ secrets.PAT_MODELS }} -filePath $filePath
+          .\createBlogPostsFromUpdates.ps1 -token ${{ secrets.PAT }} -filePath $filePath


### PR DESCRIPTION
## Summary

The GitHub Models API is being deprecated. This PR replaces it with local AI inference using **Ollama** running as a service container on the GitHub Actions runner — no external AI tokens required.

## Changes

### New: .github/actions/setup-ollama/action.yml
Composite action that:
- Caches Ollama models between runs (keyed by model tag)
- Waits for the Ollama service container to be ready
- Pulls the model if not already cached

### Updated: deploy.yml
- Added ollama/ollama:0.23.4 service container to the PostNews job
- Added Set up Ollama step using the new composite action
- Removed 	okenModels secret (no longer needed)
- Model: qwen2.5-coder:3b (small, fast, ~1.6 GB download)

### Updated: createBlogPostsFromUpdates.ps1
- Replaced CallGitHubModels (GitHub Models API) with CallOllama (local Ollama API at http://localhost:11434)
- Removed $tokenModels parameter
- Added ctionSummary to blog post front matter (YAML block scalar) so the RSS feed can use it

### Also included (from previous change):
- RSS feed <description> now uses the AI action summary when available, falling back to Hugo's auto-summary, with version/type/dependents appended

## AI Model

The model used is **qwen2.5-coder:3b** (~1.6 GB download, cached between runs). It runs entirely on the GitHub Actions runner via Ollama — no external API tokens needed. The model is small enough to pull quickly and run on CPU, while being capable enough for concise action descriptions.