### PR TITLE
Use GitHub API for version checks on known actions to cut marketplace page loads

### DIFF
--- a/.github/actions/character-to-run/action.yml
+++ b/.github/actions/character-to-run/action.yml
@@ -17,6 +17,9 @@ inputs:
     required: true
   BlobStorageConnectionString:
     required: true
+  GitHubApiToken:
+    required: false
+    default: ''
 
 runs:
   using: "composite"
@@ -57,7 +60,8 @@ runs:
         TwitterAccessToken: ${{ inputs.TwitterAccessToken }}
         TwitterAccessTokenSecret: ${{ inputs.TwitterAccessTokenSecret }}
         BlobStorageConnectionString: ${{ inputs.BlobStorageConnectionString }}
-    
+        GitHubApiToken: ${{ inputs.GitHubApiToken }}
+
     - name: Install Playwright Browsers
       shell: pwsh
       run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -86,6 +86,8 @@ jobs:
       matrix:
         character: [ba,bb,bd,bf,bm,bn,bq,bs,bt,bu,bv,c,e,g,h,j,k,l,m,n,u,w,x,y,z,o,p,r,sa,sb,sc,sd,se,sf,sg,sh,sj,sk,sl,sm,sn,sp,sr,su,sv,sw,t,v,ai,ae,ia,ea,0,1,2,3,4,5,6,7,8,9]
         #character: [c] # temp for faster testing of consolidate updates
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v3.5.3
 
@@ -100,6 +102,10 @@ jobs:
           TwitterAccessToken: 'TwitterAccessToken'
           TwitterAccessTokenSecret: 'TwitterAccessTokenSecret'
           BlobStorageConnectionString: ${{ secrets.BLOB_CONNECTION_STRING }}
+          # authenticates GitHub REST API version lookups (releases/tags) so known actions can be
+          # refreshed without loading their marketplace detail page; raises the rate limit from
+          # 60/hour (unauthenticated) to 1000/hour per repository.
+          GitHubApiToken: ${{ secrets.GITHUB_TOKEN }}
 
   ConsolidateUpdates:
     runs-on: windows-latest

--- a/AzDoExtensionNews/GitHubActionsNews.Tests/BuildExistingActionsByUrlLookup_Tests.cs
+++ b/AzDoExtensionNews/GitHubActionsNews.Tests/BuildExistingActionsByUrlLookup_Tests.cs
@@ -1,0 +1,56 @@
+using GitHubActionsNews;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using News.Library;
+using System;
+using System.Collections.Generic;
+
+namespace GitHubActionsNews.Tests
+{
+    [TestClass]
+    public class BuildExistingActionsByUrlLookup_Tests
+    {
+        [TestMethod]
+        public void BuildExistingActionsByUrlLookup_KeysByUrl_CaseInsensitively()
+        {
+            var actions = new List<GitHubAction>
+            {
+                new GitHubAction { Url = "https://github.com/marketplace/actions/checkout", RepoUrl = "https://github.com/actions/checkout", Updated = DateTime.UtcNow }
+            };
+
+            var lookup = Program.BuildExistingActionsByUrlLookup(actions);
+
+            Assert.IsTrue(lookup.ContainsKey("HTTPS://GITHUB.COM/MARKETPLACE/ACTIONS/CHECKOUT"));
+            Assert.AreEqual("https://github.com/actions/checkout", lookup["https://github.com/marketplace/actions/checkout"].RepoUrl);
+        }
+
+        [TestMethod]
+        public void BuildExistingActionsByUrlLookup_SkipsEntriesWithoutUrl()
+        {
+            var actions = new List<GitHubAction>
+            {
+                new GitHubAction { Url = null, RepoUrl = "https://github.com/actions/checkout" },
+                new GitHubAction { Url = "", RepoUrl = "https://github.com/actions/cache" }
+            };
+
+            var lookup = Program.BuildExistingActionsByUrlLookup(actions);
+
+            Assert.AreEqual(0, lookup.Count);
+        }
+
+        [TestMethod]
+        public void BuildExistingActionsByUrlLookup_PrefersMostRecentlyUpdated_OnDuplicateUrls()
+        {
+            var url = "https://github.com/marketplace/actions/checkout";
+            var actions = new List<GitHubAction>
+            {
+                new GitHubAction { Url = url, RepoUrl = "old-repo-url", Updated = DateTime.UtcNow.AddDays(-2) },
+                new GitHubAction { Url = url, RepoUrl = "new-repo-url", Updated = DateTime.UtcNow }
+            };
+
+            var lookup = Program.BuildExistingActionsByUrlLookup(actions);
+
+            Assert.AreEqual(1, lookup.Count);
+            Assert.AreEqual("new-repo-url", lookup[url].RepoUrl);
+        }
+    }
+}

--- a/AzDoExtensionNews/GitHubActionsNews.Tests/GitHubReleaseApiClient_Tests.cs
+++ b/AzDoExtensionNews/GitHubActionsNews.Tests/GitHubReleaseApiClient_Tests.cs
@@ -1,0 +1,176 @@
+using GitHubActionsNews;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GitHubActionsNews.Tests
+{
+    // Routes requests to a queue of canned responses, keyed by the requested url, so the API
+    // client can be tested without making real network calls.
+    internal class FakeHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Queue<(string UrlContains, HttpResponseMessage Response)> _responses = new();
+        public List<string> RequestedUrls { get; } = new();
+
+        public void Enqueue(string urlContains, HttpResponseMessage response)
+        {
+            _responses.Enqueue((urlContains, response));
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestedUrls.Add(request.RequestUri.ToString());
+
+            if (_responses.Count == 0)
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+            }
+
+            var (urlContains, response) = _responses.Dequeue();
+            if (!string.IsNullOrEmpty(urlContains) && !request.RequestUri.ToString().Contains(urlContains))
+            {
+                throw new InvalidOperationException($"Unexpected request to [{request.RequestUri}], expected it to contain [{urlContains}]");
+            }
+
+            return Task.FromResult(response);
+        }
+    }
+
+    [TestClass]
+    public class GitHubReleaseApiClient_Tests
+    {
+        private static HttpResponseMessage JsonResponse(HttpStatusCode statusCode, string body, int? rateLimitRemaining = 5000)
+        {
+            var response = new HttpResponseMessage(statusCode)
+            {
+                Content = new StringContent(body ?? string.Empty)
+            };
+            if (rateLimitRemaining.HasValue)
+            {
+                response.Headers.Add("X-RateLimit-Remaining", rateLimitRemaining.Value.ToString());
+            }
+            return response;
+        }
+
+        [TestMethod]
+        public async Task GetLatestVersionAsync_ReturnsTagFromReleasesLatest()
+        {
+            var handler = new FakeHttpMessageHandler();
+            handler.Enqueue("/releases/latest", JsonResponse(HttpStatusCode.OK, "{\"tag_name\":\"v4.2.0\"}"));
+            var client = new GitHubReleaseApiClient(new HttpClient(handler), "token");
+
+            var result = await client.GetLatestVersionAsync("https://github.com/actions/checkout");
+
+            Assert.IsTrue(result.Success);
+            Assert.AreEqual("v4.2.0", result.Version);
+            Assert.IsFalse(result.RateLimited);
+            Assert.AreEqual(1, handler.RequestedUrls.Count, "Should only need a single API call when releases/latest succeeds");
+        }
+
+        [TestMethod]
+        public async Task GetLatestVersionAsync_FallsBackToTags_WhenNoReleaseExists()
+        {
+            var handler = new FakeHttpMessageHandler();
+            handler.Enqueue("/releases/latest", JsonResponse(HttpStatusCode.NotFound, null));
+            handler.Enqueue("/tags", JsonResponse(HttpStatusCode.OK, "[{\"name\":\"v1.0.0\"}]"));
+            var client = new GitHubReleaseApiClient(new HttpClient(handler), "token");
+
+            var result = await client.GetLatestVersionAsync("https://github.com/owner/repo-with-only-tags");
+
+            Assert.IsTrue(result.Success);
+            Assert.AreEqual("v1.0.0", result.Version);
+            Assert.AreEqual(2, handler.RequestedUrls.Count);
+        }
+
+        [TestMethod]
+        public async Task GetLatestVersionAsync_ReturnsUnsuccessful_WhenNoReleasesOrTagsFound()
+        {
+            var handler = new FakeHttpMessageHandler();
+            handler.Enqueue("/releases/latest", JsonResponse(HttpStatusCode.NotFound, null));
+            handler.Enqueue("/tags", JsonResponse(HttpStatusCode.OK, "[]"));
+            var client = new GitHubReleaseApiClient(new HttpClient(handler), "token");
+
+            var result = await client.GetLatestVersionAsync("https://github.com/owner/empty-repo");
+
+            Assert.IsFalse(result.Success);
+            Assert.IsFalse(result.RateLimited);
+        }
+
+        [TestMethod]
+        public async Task GetLatestVersionAsync_ReturnsNotSuccessful_ForInvalidRepoUrl()
+        {
+            var handler = new FakeHttpMessageHandler();
+            var client = new GitHubReleaseApiClient(new HttpClient(handler), "token");
+
+            var result = await client.GetLatestVersionAsync("not-a-url");
+
+            Assert.IsFalse(result.Success);
+            Assert.AreEqual(0, handler.RequestedUrls.Count, "An invalid repo url should never trigger an API call");
+        }
+
+        [TestMethod]
+        public async Task GetLatestVersionAsync_MarksRateLimited_OnForbiddenResponse()
+        {
+            var handler = new FakeHttpMessageHandler();
+            var forbidden = new HttpResponseMessage(HttpStatusCode.Forbidden);
+            forbidden.Headers.Add("Retry-After", "30");
+            handler.Enqueue("/releases/latest", forbidden);
+            var client = new GitHubReleaseApiClient(new HttpClient(handler), "token");
+
+            var result = await client.GetLatestVersionAsync("https://github.com/owner/repo");
+
+            Assert.IsFalse(result.Success);
+            Assert.IsTrue(result.RateLimited);
+        }
+
+        [TestMethod]
+        public async Task GetLatestVersionAsync_StopsCallingApi_OnceRateLimitRemainingIsLow()
+        {
+            var handler = new FakeHttpMessageHandler();
+            handler.Enqueue("/releases/latest", JsonResponse(HttpStatusCode.OK, "{\"tag_name\":\"v1.0.0\"}", rateLimitRemaining: 10));
+            var client = new GitHubReleaseApiClient(new HttpClient(handler), "token");
+
+            var first = await client.GetLatestVersionAsync("https://github.com/owner/repo");
+            Assert.IsTrue(first.Success);
+            Assert.IsTrue(client.IsRateLimited, "Remaining quota of 10 is below the safety threshold and should already flag as rate limited");
+
+            // second call should short-circuit: rate limit remaining (10) is below the safety threshold
+            var second = await client.GetLatestVersionAsync("https://github.com/owner/repo2");
+
+            Assert.IsFalse(second.Success);
+            Assert.IsTrue(second.RateLimited);
+            Assert.AreEqual(1, handler.RequestedUrls.Count, "No further HTTP calls should be made once the remaining quota is below the safety threshold");
+        }
+
+        [TestMethod]
+        public void ParseOwnerRepo_ExtractsOwnerAndRepo_FromRepoUrl()
+        {
+            var (owner, repo) = GitHubReleaseApiClient.ParseOwnerRepo("https://github.com/actions/checkout");
+
+            Assert.AreEqual("actions", owner);
+            Assert.AreEqual("checkout", repo);
+        }
+
+        [TestMethod]
+        public void ParseOwnerRepo_ExtractsOwnerAndRepo_IgnoringTrailingSegments()
+        {
+            var (owner, repo) = GitHubReleaseApiClient.ParseOwnerRepo("https://github.com/actions/checkout/tree/main");
+
+            Assert.AreEqual("actions", owner);
+            Assert.AreEqual("checkout", repo);
+        }
+
+        [TestMethod]
+        public void ParseOwnerRepo_ReturnsNulls_ForMalformedUrl()
+        {
+            var (owner, repo) = GitHubReleaseApiClient.ParseOwnerRepo("https://github.com/justowner");
+
+            Assert.IsNull(owner);
+            Assert.IsNull(repo);
+        }
+    }
+}

--- a/AzDoExtensionNews/GitHubActionsNews/GitHubReleaseApiClient.cs
+++ b/AzDoExtensionNews/GitHubActionsNews/GitHubReleaseApiClient.cs
@@ -1,0 +1,269 @@
+using News.Library;
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace GitHubActionsNews
+{
+    public class GitHubReleaseLookupResult
+    {
+        public bool Success { get; set; }
+        public string Version { get; set; }
+        public bool RateLimited { get; set; }
+    }
+
+    /// <summary>
+    /// Looks up the latest release/tag for a repository via the GitHub REST API, so callers can
+    /// detect version changes without loading the marketplace detail page with Playwright.
+    /// </summary>
+    public class GitHubReleaseApiClient
+    {
+        // Stop calling the API once we get this close to the limit, so a single run never exhausts
+        // the token's remaining budget for other jobs running in the same hour.
+        private const int RateLimitSafetyThreshold = 50;
+
+        private readonly HttpClient _httpClient;
+        private readonly object _stateLock = new object();
+        private int _rateLimitRemaining = int.MaxValue;
+        private DateTimeOffset? _backoffUntil;
+
+        public GitHubReleaseApiClient(HttpClient httpClient, string token)
+        {
+            _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+
+            if (_httpClient.DefaultRequestHeaders.UserAgent.Count == 0)
+            {
+                _httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("GitHubActionsNews-Scraper");
+            }
+            if (!_httpClient.DefaultRequestHeaders.Accept.Any())
+            {
+                _httpClient.DefaultRequestHeaders.Accept.ParseAdd("application/vnd.github+json");
+            }
+            if (!_httpClient.DefaultRequestHeaders.Contains("X-GitHub-Api-Version"))
+            {
+                _httpClient.DefaultRequestHeaders.Add("X-GitHub-Api-Version", "2022-11-28");
+            }
+            if (!string.IsNullOrWhiteSpace(token) && _httpClient.DefaultRequestHeaders.Authorization == null)
+            {
+                _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            }
+        }
+
+        public bool IsRateLimited
+        {
+            get
+            {
+                lock (_stateLock)
+                {
+                    if (_backoffUntil.HasValue)
+                    {
+                        if (DateTimeOffset.UtcNow < _backoffUntil.Value)
+                        {
+                            return true;
+                        }
+                        _backoffUntil = null;
+                    }
+
+                    return _rateLimitRemaining <= RateLimitSafetyThreshold;
+                }
+            }
+        }
+
+        public static (string Owner, string Repo) ParseOwnerRepo(string repoUrl)
+        {
+            if (string.IsNullOrWhiteSpace(repoUrl))
+            {
+                return (null, null);
+            }
+
+            try
+            {
+                var uri = new Uri(repoUrl, UriKind.Absolute);
+                var segments = uri.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+                if (segments.Length < 2)
+                {
+                    return (null, null);
+                }
+
+                return (segments[0], segments[1]);
+            }
+            catch
+            {
+                return (null, null);
+            }
+        }
+
+        /// <summary>
+        /// Looks up the latest release tag, falling back to the most recent tag when the
+        /// repository has no GitHub Releases. Returns Success = false (never throws) when the
+        /// lookup could not be completed, so callers can fall back to scraping the detail page.
+        /// </summary>
+        public async Task<GitHubReleaseLookupResult> GetLatestVersionAsync(string repoUrl)
+        {
+            if (IsRateLimited)
+            {
+                return new GitHubReleaseLookupResult { Success = false, RateLimited = true };
+            }
+
+            var (owner, repo) = ParseOwnerRepo(repoUrl);
+            if (owner == null || repo == null)
+            {
+                return new GitHubReleaseLookupResult { Success = false };
+            }
+
+            var releaseResult = await FetchAsync($"https://api.github.com/repos/{owner}/{repo}/releases/latest");
+            if (releaseResult.RateLimited)
+            {
+                return new GitHubReleaseLookupResult { Success = false, RateLimited = true };
+            }
+            if (releaseResult.StatusCode == HttpStatusCode.OK)
+            {
+                var tag = ExtractTagName(releaseResult.Body);
+                if (!string.IsNullOrWhiteSpace(tag))
+                {
+                    return new GitHubReleaseLookupResult { Success = true, Version = tag };
+                }
+            }
+
+            // repos without GitHub Releases (only tags) 404 on /releases/latest
+            var tagsResult = await FetchAsync($"https://api.github.com/repos/{owner}/{repo}/tags?per_page=1");
+            if (tagsResult.RateLimited)
+            {
+                return new GitHubReleaseLookupResult { Success = false, RateLimited = true };
+            }
+            if (tagsResult.StatusCode == HttpStatusCode.OK)
+            {
+                var tag = ExtractFirstTagName(tagsResult.Body);
+                if (!string.IsNullOrWhiteSpace(tag))
+                {
+                    return new GitHubReleaseLookupResult { Success = true, Version = tag };
+                }
+            }
+
+            return new GitHubReleaseLookupResult { Success = false };
+        }
+
+        private async Task<(HttpStatusCode StatusCode, string Body, bool RateLimited)> FetchAsync(string url)
+        {
+            try
+            {
+                using var response = await _httpClient.GetAsync(url);
+                UpdateRateLimitState(response);
+
+                if (response.StatusCode == HttpStatusCode.Forbidden || (int)response.StatusCode == 429)
+                {
+                    ApplyRetryAfter(response);
+                    Log.Message($"GitHub API rate/abuse limit hit for [{url}], status [{response.StatusCode}]");
+                    return (response.StatusCode, null, true);
+                }
+
+                var body = await response.Content.ReadAsStringAsync();
+                return (response.StatusCode, body, false);
+            }
+            catch (Exception e)
+            {
+                Log.Message($"Error calling GitHub API [{url}]: {e.Message}");
+                return (HttpStatusCode.ServiceUnavailable, null, false);
+            }
+        }
+
+        private void UpdateRateLimitState(HttpResponseMessage response)
+        {
+            if (!response.Headers.TryGetValues("X-RateLimit-Remaining", out var values))
+            {
+                return;
+            }
+
+            var value = values.FirstOrDefault();
+            if (!int.TryParse(value, out var remaining))
+            {
+                return;
+            }
+
+            lock (_stateLock)
+            {
+                _rateLimitRemaining = remaining;
+            }
+
+            if (remaining <= RateLimitSafetyThreshold)
+            {
+                Log.Message($"GitHub API rate limit remaining is low [{remaining}]; further version lookups this run will fall back to marketplace scraping.");
+            }
+        }
+
+        private void ApplyRetryAfter(HttpResponseMessage response)
+        {
+            TimeSpan backoff;
+            if (response.Headers.TryGetValues("Retry-After", out var values) &&
+                int.TryParse(values.FirstOrDefault(), out var seconds))
+            {
+                backoff = TimeSpan.FromSeconds(seconds);
+            }
+            else
+            {
+                // No Retry-After header: back off conservatively rather than hammering the API.
+                backoff = TimeSpan.FromMinutes(1);
+            }
+
+            lock (_stateLock)
+            {
+                _backoffUntil = DateTimeOffset.UtcNow.Add(backoff);
+            }
+        }
+
+        internal static string ExtractTagName(string releaseJson)
+        {
+            if (string.IsNullOrWhiteSpace(releaseJson))
+            {
+                return null;
+            }
+
+            try
+            {
+                using var doc = JsonDocument.Parse(releaseJson);
+                if (doc.RootElement.ValueKind == JsonValueKind.Object &&
+                    doc.RootElement.TryGetProperty("tag_name", out var tagNameElement))
+                {
+                    return tagNameElement.GetString();
+                }
+            }
+            catch (JsonException)
+            {
+                // malformed/unexpected response body, treat as "no version found"
+            }
+
+            return null;
+        }
+
+        internal static string ExtractFirstTagName(string tagsJson)
+        {
+            if (string.IsNullOrWhiteSpace(tagsJson))
+            {
+                return null;
+            }
+
+            try
+            {
+                using var doc = JsonDocument.Parse(tagsJson);
+                if (doc.RootElement.ValueKind == JsonValueKind.Array && doc.RootElement.GetArrayLength() > 0)
+                {
+                    var first = doc.RootElement[0];
+                    if (first.TryGetProperty("name", out var nameElement))
+                    {
+                        return nameElement.GetString();
+                    }
+                }
+            }
+            catch (JsonException)
+            {
+                // malformed/unexpected response body, treat as "no version found"
+            }
+
+            return null;
+        }
+    }
+}

--- a/AzDoExtensionNews/GitHubActionsNews/Program.cs
+++ b/AzDoExtensionNews/GitHubActionsNews/Program.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -16,6 +17,13 @@ namespace GitHubActionsNews
         private const string GitHubMarketplaceUrl = "https://github.com/marketplace?type=actions";
         private static readonly string StorageFileName = "Actions";
         private static Twitter twitter;
+
+        // Created lazily (after Configuration.LoadSettings runs) rather than as an eager static
+        // field, so unit tests that touch the Program class without loading configuration keep working.
+        private static readonly Lazy<GitHubReleaseApiClient> LazyGitHubApiClient =
+            new Lazy<GitHubReleaseApiClient>(() => new GitHubReleaseApiClient(new HttpClient(), Configuration.GitHubApiToken));
+
+        private static GitHubReleaseApiClient GitHubApiClient => LazyGitHubApiClient.Value;
 
         static async Task Main(string[] args)
         {
@@ -219,6 +227,14 @@ namespace GitHubActionsNews
         {
             var actions = new List<GitHubAction>();
             var started = DateTime.Now;
+
+            var storeFileName = $"{StorageFileName}-{query}";
+            // get existing actions for this query up front, so the scrape below can look up
+            // actions we already know the RepoUrl for and check their version via the GitHub API
+            // instead of loading their marketplace detail page with Playwright.
+            var existingActions = Storage.ReadFromJson<GitHubAction>(storeFileName, storeFileName);
+            var existingActionsByUrl = BuildExistingActionsByUrlLookup(existingActions);
+
             // check if query is a single letter, but is not a number
             if (query.Length == 1 && !int.TryParse(query, out var a))
             {
@@ -234,7 +250,7 @@ namespace GitHubActionsNews
                     {
                         Log.Message($"Loading latest states for all actions starting with [{twoLetterQuery}]");
                         var queriedGitHubMarketplaceUrl = $"{GitHubMarketplaceUrl}&query={twoLetterQuery}";
-                        actions.AddRange(await GetAllActionsAsync(queriedGitHubMarketplaceUrl));
+                        actions.AddRange(await GetAllActionsAsync(queriedGitHubMarketplaceUrl, existingActionsByUrl, GitHubApiClient));
                     }
                 }
             }
@@ -243,7 +259,7 @@ namespace GitHubActionsNews
                 Log.Message($"Loading latest states for all actions starting with [{query}]");
 
                 var queriedGitHubMarketplaceUrl = $"{GitHubMarketplaceUrl}&query={query}";
-                actions.AddRange(await GetAllActionsAsync(queriedGitHubMarketplaceUrl));
+                actions.AddRange(await GetAllActionsAsync(queriedGitHubMarketplaceUrl, existingActionsByUrl, GitHubApiClient));
             }
 
             if (actions.Count == 0 && 1 == 3) // this is a temporary fix to avoid an exception when running with the new UI refresh
@@ -252,10 +268,6 @@ namespace GitHubActionsNews
                 // throw so that a run will fail and e.g. a workflow indicates failure
                 throw new Exception($"No actions found for query [{query}]");
             }
-
-            var storeFileName = $"{StorageFileName}-{query}";
-            // get existing actions for this query:
-            var existingActions = Storage.ReadFromJson<GitHubAction>(storeFileName, storeFileName);
 
             // tweet about updates and new actions:
             var repoUrlUpdates = 0;
@@ -350,11 +362,40 @@ namespace GitHubActionsNews
             return GetAllActionsAsync(searchUrl).GetAwaiter().GetResult();
         }
 
-        internal static async Task<List<GitHubAction>> GetAllActionsAsync(string searchUrl)
+        // Builds a lookup of the actions we already know about, keyed by their (normalized)
+        // marketplace detail-page url, so ParseActionAsync can find a known RepoUrl to check via
+        // the GitHub API instead of opening the detail page with Playwright.
+        internal static Dictionary<string, GitHubAction> BuildExistingActionsByUrlLookup(List<GitHubAction> existingActions)
+        {
+            var lookup = new Dictionary<string, GitHubAction>(StringComparer.OrdinalIgnoreCase);
+            foreach (var action in existingActions)
+            {
+                if (string.IsNullOrWhiteSpace(action.Url))
+                {
+                    continue;
+                }
+
+                // if duplicate urls exist, prefer the most recently updated entry
+                if (!lookup.TryGetValue(action.Url, out var current) ||
+                    (action.Updated ?? DateTime.MinValue) > (current.Updated ?? DateTime.MinValue))
+                {
+                    lookup[action.Url] = action;
+                }
+            }
+
+            return lookup;
+        }
+
+        internal static Task<List<GitHubAction>> GetAllActionsAsync(string searchUrl)
+        {
+            return GetAllActionsAsync(searchUrl, null, null);
+        }
+
+        internal static async Task<List<GitHubAction>> GetAllActionsAsync(string searchUrl, IReadOnlyDictionary<string, GitHubAction> existingActionsByUrl, GitHubReleaseApiClient apiClient)
         {
             try
             {
-                var actions = await ScrapeGitHubMarketPlaceAsync(searchUrl);
+                var actions = await ScrapeGitHubMarketPlaceAsync(searchUrl, existingActionsByUrl, apiClient);
 
                 return actions;
             }
@@ -367,7 +408,7 @@ namespace GitHubActionsNews
             return [];
         }
 
-        private static async Task<List<GitHubAction>> ScrapeGitHubMarketPlaceAsync(string searchUrl)
+        private static async Task<List<GitHubAction>> ScrapeGitHubMarketPlaceAsync(string searchUrl, IReadOnlyDictionary<string, GitHubAction> existingActionsByUrl, GitHubReleaseApiClient apiClient)
         {
             var started = DateTime.Now;
             Console.WriteLine("Running");
@@ -381,7 +422,7 @@ namespace GitHubActionsNews
             {
                 await page.GotoAsync(searchUrl);
                 var sb = new StringBuilder();
-                var actionList = await ScrapePageAsync(page, 1, sb);
+                var actionList = await ScrapePageAsync(page, 1, sb, existingActionsByUrl, apiClient);
                 var emptyRepoUrl = actionList.Where(x => String.IsNullOrEmpty(x.RepoUrl)).Count();
 
                 Log.Message($"Found {actionList.Count} actions for search url [{searchUrl}] in {(DateTime.Now - started).TotalMinutes:N2} minutes, with [{emptyRepoUrl}] not filled repo urls", logsummary: true);
@@ -449,10 +490,10 @@ namespace GitHubActionsNews
 
         private static List<GitHubAction> ScrapePage(IPage page, int pageNumber, StringBuilder logger)
         {
-            return ScrapePageAsync(page, pageNumber, logger).GetAwaiter().GetResult();
+            return ScrapePageAsync(page, pageNumber, logger, null, null).GetAwaiter().GetResult();
         }
 
-        private static async Task<List<GitHubAction>> ScrapePageAsync(IPage page, int pageNumber, StringBuilder logger)
+        private static async Task<List<GitHubAction>> ScrapePageAsync(IPage page, int pageNumber, StringBuilder logger, IReadOnlyDictionary<string, GitHubAction> existingActionsByUrl, GitHubReleaseApiClient apiClient)
         {
             var actionList = new List<GitHubAction>();
             try
@@ -482,8 +523,11 @@ namespace GitHubActionsNews
 
                 foreach (var action in actionTags)
                 {
-                    var ghAction = await ParseActionAsync(action, page);
-                    Thread.Sleep(2000); // try to cut down on ratelimit messages
+                    var (ghAction, usedMarketplacePage) = await ParseActionAsync(action, page, existingActionsByUrl, apiClient);
+                    if (usedMarketplacePage)
+                    {
+                        Thread.Sleep(2000); // try to cut down on ratelimit messages - only needed when we actually loaded a marketplace page
+                    }
                     if (ghAction != null)
                     {
                         actionList.Add(ghAction);
@@ -558,7 +602,7 @@ namespace GitHubActionsNews
                     }
 
                     // scrape the new page again
-                    actionList.AddRange(await ScrapePageAsync(page, pageNumber + 1, logger));
+                    actionList.AddRange(await ScrapePageAsync(page, pageNumber + 1, logger, existingActionsByUrl, apiClient));
                 }
                 else
                 {
@@ -624,20 +668,55 @@ namespace GitHubActionsNews
 
         private static GitHubAction ParseAction(ILocator action, IPage page)
         {
-            return ParseActionAsync(action, page).GetAwaiter().GetResult();
+            return ParseActionAsync(action, page, null, null).GetAwaiter().GetResult().Action;
         }
 
-        private static async Task<GitHubAction> ParseActionAsync(ILocator action, IPage page)
+        private static async Task<(GitHubAction Action, bool UsedMarketplacePage)> ParseActionAsync(ILocator action, IPage page, IReadOnlyDictionary<string, GitHubAction> existingActionsByUrl, GitHubReleaseApiClient apiClient)
         {
             try
             {
                 var href = await action.GetAttributeAsync("href");
                 if (string.IsNullOrWhiteSpace(href))
                 {
-                    return null;
+                    return (null, false);
                 }
 
                 var url = NormalizeMarketplaceUrl(href);
+
+                // Fast path: for actions we already know about with a repo url, check for a
+                // version change via the GitHub REST API instead of opening a Playwright detail
+                // page. Falls through to the full page scrape below when the action is new, has
+                // no known repo url, or the API lookup could not be completed (rate limited, no
+                // releases/tags found, network error, etc).
+                if (existingActionsByUrl != null && apiClient != null &&
+                    existingActionsByUrl.TryGetValue(url, out var existingAction) &&
+                    !string.IsNullOrWhiteSpace(existingAction.RepoUrl))
+                {
+                    var lookup = await apiClient.GetLatestVersionAsync(existingAction.RepoUrl);
+                    if (lookup.Success)
+                    {
+                        Log.Message($"Found version [{lookup.Version}] for url [{url}] via GitHub API (RepoUrl [{existingAction.RepoUrl}]), skipped marketplace page load");
+                        return (new GitHubAction
+                        {
+                            Url = url,
+                            Title = existingAction.Title,
+                            Publisher = existingAction.Publisher,
+                            Version = lookup.Version,
+                            Updated = DateTime.UtcNow,
+                            RepoUrl = existingAction.RepoUrl,
+                            Verified = existingAction.Verified,
+                            ActionType = existingAction.ActionType,
+                            NodeVersion = existingAction.NodeVersion
+                        }, false);
+                    }
+
+                    if (lookup.RateLimited)
+                    {
+                        Log.Message($"GitHub API rate limit reached; falling back to marketplace page for [{url}]");
+                    }
+                    // otherwise: no releases/tags found or a transient API error - fall back below
+                }
+
                 var title = "content";
                 var publisher = "";
 
@@ -728,7 +807,7 @@ namespace GitHubActionsNews
                 // closing the new page
                 await newPage.CloseAsync();
 
-                return new GitHubAction
+                return (new GitHubAction
                 {
                     Url = url,
                     Title = title,
@@ -739,12 +818,12 @@ namespace GitHubActionsNews
                     Verified = verified,
                     ActionType = null,  // Will be populated later for new/updated actions only
                     NodeVersion = null  // Will be populated later for new/updated actions only
-                };
+                }, true);
             }
             catch (Exception e)
             {
                 Log.Message($"Error parsing action: {e.Message}");
-                return null;
+                return (null, false);
             }
         }
 

--- a/AzDoExtensionNews/GitHubActionsNews/appsettings.json
+++ b/AzDoExtensionNews/GitHubActionsNews/appsettings.json
@@ -4,5 +4,6 @@
   "TwitterConsumerAPISecretKey": "TwitterConsumerAPISecretKey",
   "TwitterAccessToken": "TwitterAccessToken",
   "TwitterAccessTokenSecret": "TwitterAccessTokenSecret",
-  "BlobStorageConnectionString": "BlobStorageConnectionString"
+  "BlobStorageConnectionString": "BlobStorageConnectionString",
+  "GitHubApiToken": "GitHubApiToken"
 }

--- a/AzDoExtensionNews/News.Library/Configuration.cs
+++ b/AzDoExtensionNews/News.Library/Configuration.cs
@@ -65,6 +65,30 @@ namespace News.Library
             }
         }
 
+        private static string _GitHubApiToken;
+
+        /// <summary>
+        /// Optional token used to authenticate GitHub REST API calls (releases/tags lookups).
+        /// Falls back to unauthenticated calls (60 requests/hour) when not set, so it is not required.
+        /// </summary>
+        public static string GitHubApiToken
+        {
+            get
+            {
+                if (!_settingsLoaded)
+                {
+                    LoadSettings();
+                }
+
+                return _GitHubApiToken;
+            }
+
+            set
+            {
+                _GitHubApiToken = value;
+            }
+        }
+
         public static void LoadSettings()
         {
             IConfiguration config = new ConfigurationBuilder()
@@ -79,6 +103,12 @@ namespace News.Library
             var twitterAccessTokenSecret = config["TwitterAccessTokenSecret"];
             var rawConnectionString = config["BlobStorageConnectionString"];
             var normalizedBlobConnectionString = NormalizeBlobStorageConnectionString(rawConnectionString);
+            var gitHubApiToken = NormalizeOptionalSetting(config["GitHubApiToken"], nameof(GitHubApiToken));
+            if (string.IsNullOrWhiteSpace(gitHubApiToken))
+            {
+                // GITHUB_TOKEN is provided automatically in GitHub Actions workflows
+                gitHubApiToken = Environment.GetEnvironmentVariable("GITHUB_TOKEN");
+            }
 
             // check them all
             if (String.IsNullOrEmpty(twitterConsumerApiKey)) throw new ConfigurationException($"Error loading value for {nameof(TwitterConsumerAPIKey)}");
@@ -92,6 +122,12 @@ namespace News.Library
             TwitterAccessToken = twitterAccessToken;
             TwitterAccessTokenSecret = twitterAccessTokenSecret;
             _BlobStorageConnectionString = normalizedBlobConnectionString;
+            _GitHubApiToken = gitHubApiToken;
+
+            if (string.IsNullOrWhiteSpace(_GitHubApiToken))
+            {
+                Log.Message($"{nameof(GitHubApiToken)} not configured. GitHub API version lookups will be unauthenticated (60 requests/hour) or skipped once that limit is reached.");
+            }
 
             var hasBlobStorageConfiguration = !string.IsNullOrWhiteSpace(_BlobStorageConnectionString);
 
@@ -112,6 +148,18 @@ namespace News.Library
         private static string NormalizeBlobStorageConnectionString(string value)
         {
             if (string.IsNullOrWhiteSpace(value) || value == nameof(BlobStorageConnectionString))
+            {
+                return null;
+            }
+
+            return value;
+        }
+
+        // Guards against the appsettings.json placeholder value (e.g. "GitHubApiToken") being
+        // treated as a real, configured value when variable substitution did not run.
+        private static string NormalizeOptionalSetting(string value, string settingName)
+        {
+            if (string.IsNullOrWhiteSpace(value) || value == settingName)
             {
                 return null;
             }


### PR DESCRIPTION
## Summary

Every 8h run of the scraper (matrix of ~60 letter-combination jobs, ~20k actions total) opened a **new Playwright tab against the marketplace detail page for every single action, on every run**, plus a 2s sleep per action — just to check whether the version had changed. Most versions don't change between runs, so nearly all of that was wasted marketplace traffic against GitHub's (secondary) rate limits.

### Before
- Every action (known or new) → 1 Playwright page load of `https://github.com/marketplace/actions/{slug}` + `Thread.Sleep(2000)`.
- ~20k actions × up to 4 runs/day (every 8h across the matrix) = tens of thousands of marketplace detail-page loads/day, regardless of whether anything changed.

### After
- Actions we already have in the stored `Actions-{query}.json` **with a known `RepoUrl`** are checked via `GET /repos/{owner}/{repo}/releases/latest` (falling back to `/tags` for repos without GitHub Releases) instead of loading the marketplace page.
- The marketplace detail page (Playwright) is only opened for actions that are:
  - new (not yet in stored JSON), or
  - missing a `RepoUrl`, or
  - where the API lookup fails (no releases/tags, network error, or rate-limited).
- No Playwright page load → no 2s sleep either (only applied when a marketplace page was actually loaded).
- For a steady-state run where most of the ~20k actions are already known with a `RepoUrl`, this turns the bulk of the work into lightweight REST API calls instead of full browser page loads — expected reduction of well over 90% in marketplace detail-page loads per run, dropping to roughly the count of genuinely new/repo-less actions.

### Rate limit handling
`GitHubReleaseApiClient` (new, [GitHubReleaseApiClient.cs](AzDoExtensionNews/GitHubActionsNews/GitHubReleaseApiClient.cs)):
- Uses an authenticated token when available (falls back to unauthenticated 60 req/hour otherwise).
- Tracks `X-RateLimit-Remaining` and stops calling the API once it drops below a safety threshold for the rest of the run, falling back to the existing Playwright path.
- Honors `Retry-After` on 403/429 responses with a backoff window; a run degrades gracefully rather than failing.

### Token wiring
- `GITHUB_TOKEN` (auto-provided per job) is passed through `character-to-run` as an optional `GitHubApiToken` input → `appsettings.json` substitution → `Configuration.GitHubApiToken`, which also falls back to the `GITHUB_TOKEN` env var directly if not otherwise configured. Not required — the app still works unauthenticated, just at a lower rate limit.

### Storage format
Unchanged — no fields removed or renamed on `GitHubAction`; the fast path reuses `Title`/`Publisher`/`Verified`/`ActionType`/`NodeVersion` from the existing record and only refreshes `Version`/`Updated`.

### Explicitly out of scope (per request)
- `skipLetterCombo` list and three-letter query splitting are untouched.
- Did not restructure the workflow's cron schedule in this PR.

### Suggested follow-up (not included here)
Now that refreshing known actions is cheap (API calls, not page loads), it could be worth running a lightweight "newest actions" discovery pass more frequently (e.g. hourly) while keeping the full `a`-`z` sweep on the existing 8h cadence — new actions still require a full marketplace listing scrape to discover, but this PR makes the steady-state refresh part of that far cheaper.

## Test plan
- [x] `dotnet build AzDoExtensionNews.sln -c Release` succeeds.
- [x] `dotnet test AzDoExtensionNews.sln` passes (21 tests in `GitHubActionsNews.Tests`, including new coverage below).
- [x] New tests added:
  - `GitHubReleaseApiClient_Tests.cs` — releases/latest success path, tags fallback when no release exists, no-match handling, invalid repo URL, 403/Retry-After rate-limit handling, and that the client stops calling the API once remaining quota is below the safety threshold.
  - `BuildExistingActionsByUrlLookup_Tests.cs` — URL-keyed lookup construction used to find known actions during scraping (case-insensitivity, skipping entries without a URL, preferring the most-recently-updated duplicate).
- [ ] Manual verification against the live workflow (scheduled run) to confirm the reduction in marketplace page loads/log volume, since this can't be exercised end-to-end outside CI (real GitHub marketplace + Playwright).

🤖 Generated with [Claude Code](https://claude.com/claude-code)